### PR TITLE
fix: add missing dsh-client devDependencies (source build fails)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,12 @@
     "jsdom": "^26.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.0",
+    "@deepseek-ai/dsh-client-locale": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-runtime": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-ui-primitives": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-ui-settings": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-ui-slots": "0.1.0-rc.6"
   },
   "scripts": {
     "build": "node scripts/prepare.mjs",


### PR DESCRIPTION
The client build fails from a clean checkout because `src/client/index.ts` and `McpPanelTab.tsx` import modules whose packages are not declared in `devDependencies`:

- `@deepseek-ai/dsh-client-locale`
- `@deepseek-ai/dsh-client-runtime` (as `@deepseek-ai/dsh-client-runtime/client`)
- `@deepseek-ai/dsh-client-ui-primitives`
- `@deepseek-ai/dsh-client-ui-settings` (as `@deepseek-ai/dsh-client-ui-settings/client`)
- `@deepseek-ai/dsh-client-ui-slots`

Without these, `npm run build` fails with TS2307 (cannot find module). Verified: after adding these deps (all `0.1.0-rc.6`), the build completes and produces `lib/index.js`, `lib/typert.host.js`, and `lib/client.js`.