### PR TITLE
feat: probe stdio MCP servers with an initialize handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Stdio connectivity probes: `mcp_probe`, the panel probe action, `/mcp <server> probe`, and the optional passive probe now work for stdio MCP servers too. The probe spawns the configured command, completes one MCP `initialize` handshake over stdio, and records the sanitized server name/version (or a sanitized failure) in the panel; previously only streamable-http endpoints could be probed.
 ## [0.3.0] - 2026-08-15
 
 ### Added

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -13,6 +13,8 @@ import type { JobHooks, JobOutcome, JobRegistry } from '@deepseek-ai/dsh-jobs'
 import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import { sanitizeError, sanitizeText } from './sanitize.ts'
+import { spawn } from 'node:child_process'
+import { scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
 import type { McpPanelService } from './service.ts'
 
 /** Producer kind; also the job-id prefix. */
@@ -41,6 +43,16 @@ export interface ProbeOutcome {
   detail: string
 }
 
+/** One configured server's probe spec: an HTTP endpoint or a stdio launch. */
+export type ProbeTarget =
+  | { readonly kind: 'http'; readonly url: string; readonly headers: Record<string, string> }
+  | {
+      readonly kind: 'stdio'
+      readonly command: string
+      readonly args: readonly string[]
+      readonly env: Record<string, string>
+      readonly cwd?: string
+    }
 /** Display cap for server-reported name/version fields in probe details. */
 const DISPLAY_LIMIT = 80
 
@@ -120,11 +132,93 @@ export async function probeEndpoint(
  * @param timeoutMs - probe deadline.
  * @returns the registry hooks.
  */
-export function probeJob(url: string, headers: Readonly<Record<string, string>>, timeoutMs: number): JobHooks {
+export async function probeStdio(
+  target: Extract<ProbeTarget, { kind: 'stdio' }>,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<ProbeOutcome> {
+  const started = Date.now()
+  return new Promise<ProbeOutcome>((resolve) => {
+    let settled = false
+    let child: ReturnType<typeof spawn> | undefined
+    let buffer = ''
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const finish = (outcome: ProbeOutcome): void => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) clearTimeout(timer)
+      try { child?.kill() } catch {}
+      resolve(outcome)
+    }
+    timer = setTimeout(() => {
+      if (!settled) finish({ status: 'failed', detail: `timeout after ${timeoutMs}ms or cancelled` })
+    }, timeoutMs)
+    try {
+      child = spawn(target.command, [...target.args], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...scrubbedParentEnv(), ...target.env },
+        ...(target.cwd !== undefined && target.cwd !== '' ? { cwd: target.cwd } : {}),
+        windowsHide: true,
+      })
+    } catch (error) {
+      finish({ status: 'failed', detail: sanitizeError(error) })
+      return
+    }
+    child.on('error', (error) => finish({ status: 'failed', detail: sanitizeError(error) }))
+    child.on('exit', (code, signalName) => {
+      if (!settled) {
+        finish({ status: 'failed', detail: `process exited before initialize response (code ${code ?? 'null'}${signalName ? `, signal ${signalName}` : ''})` })
+      }
+    })
+    child.stdout?.on('data', (chunk) => {
+      buffer += chunk.toString('utf8')
+      let index: number
+      while ((index = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, index).trim()
+        buffer = buffer.slice(index + 1)
+        if (line === '') continue
+        let message: { id?: unknown; result?: { serverInfo?: { name?: unknown; version?: unknown } } } | undefined
+        try {
+          message = JSON.parse(line) as typeof message
+        } catch {
+          continue
+        }
+        if (message !== null && typeof message === 'object' && message.id === 1 && message.result !== undefined) {
+          const serverInfo = message.result.serverInfo ?? {}
+          const name = typeof serverInfo.name === 'string' && serverInfo.name !== ''
+            ? boundedDisplay(sanitizeText(serverInfo.name))
+            : 'unnamed'
+          const version = typeof serverInfo.version === 'string' && serverInfo.version !== ''
+            ? boundedDisplay(sanitizeText(serverInfo.version))
+            : 'unknown version'
+          finish({ status: 'completed', detail: `MCP initialize ok over stdio (server ${name} ${version}) in ${Date.now() - started}ms` })
+          return
+        }
+      }
+    })
+    child.stderr?.on('data', () => { /* never rendered */ })
+    signal.addEventListener('abort', () => {
+      if (!settled) finish({ status: 'failed', detail: `timeout after ${timeoutMs}ms or cancelled` })
+    }, { once: true })
+    try {
+      child.stdin?.write(`${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: INITIALIZE_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: PROBE_CLIENT_INFO,
+        },
+      })}\n`)
+    } catch {}
+  })
+}
+export function probeJob(target: ProbeTarget, timeoutMs: number): JobHooks {
   const controller = new AbortController()
   const timer = setTimeout(() => { controller.abort() }, timeoutMs)
   timer.unref?.()
-  const done: Promise<JobOutcome> = probeEndpoint(url, headers, timeoutMs, controller.signal)
+  const done: Promise<JobOutcome> = (target.kind === 'stdio' ? probeStdio(target, timeoutMs, controller.signal) : probeEndpoint(target.url, target.headers, timeoutMs, controller.signal))
     .then(outcome => ({ ...outcome }))
     .finally(() => { clearTimeout(timer) })
   return {
@@ -138,7 +232,7 @@ function probeTarget(
   service: McpPanelService,
   server: string,
 ): { url: string; headers: Record<string, string> } | undefined {
-  return service.rawEndpoint(server)
+  return service.probeSpec(server)
 }
 
 /**
@@ -152,13 +246,13 @@ function probeTarget(
 export function mcpProbeTool(service: McpPanelService, jobs: JobRegistry, timeoutMs: number): ToolDefinition {
   return defineTool({
     name: 'mcp_probe',
-    description: 'Run a one-shot connectivity probe of a configured streamable-http MCP server as a background job. '
+    description: 'Run a one-shot connectivity probe of a configured MCP server (stdio or streamable-http) as a background job. '
       + 'Results appear in the MCP settings panel only — they are not injected into model context.',
     parameters: {
       server: {
         type: 'string',
         required: true,
-        description: 'serverName of a configured streamable-http MCP server (see /mcp for the list).',
+        description: 'serverName of a configured MCP server (see /mcp for the list); stdio and streamable-http transports are both supported.',
       },
     },
     output: {
@@ -179,15 +273,14 @@ export function mcpProbeTool(service: McpPanelService, jobs: JobRegistry, timeou
       const target = probeTarget(service, args.server)
       if (target === undefined) {
         throw new Error(
-          `mcp_probe: "${args.server}" is not a configured streamable-http MCP server (see /mcp). `
-          + 'stdio servers have no HTTP endpoint to probe.',
+          `mcp_probe: "${args.server}" is not a configured MCP server (see /mcp).`
         )
       }
       const jobId = jobs.start({
         kind: PROBE_KIND,
         label: `mcp_probe ${args.server}`,
         // Unowned: no model completion notice, readable by the panel only.
-        run: () => probeJob(target.url, target.headers, timeoutMs),
+        run: () => probeJob(target, timeoutMs),
       })
       return {
         jobId,

--- a/src/service.ts
+++ b/src/service.ts
@@ -31,7 +31,7 @@ import {
   type McpLoaderRow,
 } from './aggregate.ts'
 import { groupMcpTools } from './grouping.ts'
-import { probeEndpoint, probeJob, PROBE_KIND } from './probe.ts'
+import { probeEndpoint, probeJob, probeStdio, PROBE_KIND, type ProbeTarget } from './probe.ts'
 import { sanitizeText } from './sanitize.ts'
 import type { McpServerStatus, McpStatusPhase } from './upstream.ts'
 import type { McpFiberPhase, McpPanelSnapshot, McpProbeView, ProbeStarted } from './wire.ts'
@@ -225,9 +225,9 @@ export class McpPanelService extends TypertRemoteService {
    * @returns the started job id and where the result lands.
    */
   probe(serverName: string): ProbeStarted {
-    const target = this.rawEndpoint(serverName)
+    const target = this.probeSpec(serverName)
     if (target === undefined) {
-      throw new Error(`dsh-mcp-panel: "${serverName}" is not a configured streamable-http MCP server`)
+      throw new Error(`dsh-mcp-panel: "${serverName}" is not a configured MCP server`)
     }
     const jobs = this.ctx.get('jobs')
     if (jobs === undefined) {
@@ -237,7 +237,7 @@ export class McpPanelService extends TypertRemoteService {
       kind: PROBE_KIND,
       label: `mcp_probe ${serverName}`,
       // Unowned: no model completion notice, readable by the panel only.
-      run: () => probeJob(target.url, target.headers, this.config.probeTimeoutMs),
+      run: () => probeJob(target, this.config.probeTimeoutMs),
     })
     return {
       jobId,
@@ -253,9 +253,9 @@ export class McpPanelService extends TypertRemoteService {
       for (const entry of this.ctx.loader.entries()) {
         if (entry.options.name !== MCP_CLIENT_MODULE) continue
         const serverName = serverNameOf(entry.options.config, `entry:${entry.options.id}`)
-        const target = this.rawEndpoint(serverName)
+        const target = this.probeSpec(serverName)
         if (target === undefined) continue
-        const outcome = await probeEndpoint(target.url, target.headers, this.config.probeTimeoutMs, AbortSignal.timeout(this.config.probeTimeoutMs))
+        const outcome = target.kind === 'stdio' ? await probeStdio(target, this.config.probeTimeoutMs, AbortSignal.timeout(this.config.probeTimeoutMs)) : await probeEndpoint(target.url, target.headers, this.config.probeTimeoutMs, AbortSignal.timeout(this.config.probeTimeoutMs))
         this.probeStates.set(serverName, { state: outcome.status === 'completed' ? 'reachable' : 'unreachable', checkedAt: Date.now() })
       }
     } finally {
@@ -298,6 +298,60 @@ export class McpPanelService extends TypertRemoteService {
     return undefined
   }
 
+  /**
+   * Resolve one server's probe spec: the raw HTTP endpoint + headers for a
+   * streamable-http row, or the stdio launch spec (command/args/env/cwd) for
+   * a stdio row. Credentials stay inside this return value and are used for
+   * the probe request only — they never reach a snapshot, a log, or a display.
+   *
+   * @param serverName - configured namespace.
+   * @returns the probe spec, or `undefined` when the row is missing or malformed.
+   */
+  probeSpec(serverName: string): ProbeTarget | undefined {
+    for (const entry of this.ctx.loader.entries()) {
+      if (entry.options.name !== MCP_CLIENT_MODULE) continue
+      const config = entry.options.config
+      if (serverNameOf(config, `entry:${entry.options.id}`) !== serverName) continue
+      if (typeof config !== 'object' || config === null || Array.isArray(config)) return undefined
+      const row = config as Record<string, unknown>
+      if (row['transport'] === 'streamable-http') {
+        const url = row['url']
+        if (typeof url !== 'string' || url === '') return undefined
+        const headersValue = row['headers']
+        const headers: Record<string, string> = {}
+        if (typeof headersValue === 'object' && headersValue !== null && !Array.isArray(headersValue)) {
+          for (const [name, value] of Object.entries(headersValue as Record<string, unknown>)) {
+            if (typeof value === 'string') headers[name] = value
+          }
+        }
+        return { kind: 'http', url, headers }
+      }
+      if (row['transport'] === 'stdio') {
+        const command = row['command']
+        if (typeof command !== 'string' || command === '') return undefined
+        const argsValue = row['args']
+        const args: string[] = []
+        if (Array.isArray(argsValue)) for (const arg of argsValue) if (typeof arg === 'string') args.push(arg)
+        const envValue = row['env']
+        const env: Record<string, string> = {}
+        if (typeof envValue === 'object' && envValue !== null && !Array.isArray(envValue)) {
+          for (const [name, value] of Object.entries(envValue as Record<string, unknown>)) {
+            if (typeof value === 'string') env[name] = value
+          }
+        }
+        const cwdValue = row['cwd']
+        return {
+          kind: 'stdio',
+          command,
+          args,
+          env,
+          ...(typeof cwdValue === 'string' && cwdValue !== '' ? { cwd: cwdValue } : {}),
+        }
+      }
+      return undefined
+    }
+    return undefined
+  }
   /** Unowned `mcp-probe` background jobs, newest first, sanitized for display. */
   private probeViews(): McpProbeView[] {
     const jobs = this.ctx.get('jobs')

--- a/tests/probe.spec.ts
+++ b/tests/probe.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { probeEndpoint, probeJob } from '../src/probe.ts'
+import { probeEndpoint, probeJob, probeStdio } from '../src/probe.ts'
 
 /** Minimal fetch Response face the probe reads. */
 function fakeResponse(status: number, statusText: string, jsonBody?: unknown): Response {
@@ -119,5 +119,30 @@ describe('probeJob', () => {
     const hooks = probeJob('https://example.com/mcp', {}, 1000)
     const outcome = await hooks.done
     expect(outcome.status).toBe('completed')
+  })
+})
+describe('probeStdio', () => {
+  const NEVER_ABORTED = new AbortController().signal
+
+  it('completes an initialize handshake over a real stdio child', async () => {
+    const script = 'const line = await new Promise((r) => process.stdin.once("data", (d) => r(d.toString())))'
+      + '; process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { serverInfo: { name: "fake-stdio", version: "9.9.9" } } }) + "\\n")'
+    const outcome = await probeStdio(
+      { kind: 'stdio', command: process.execPath, args: ['-e', script], env: {} },
+      5000,
+      NEVER_ABORTED,
+    )
+    expect(outcome.status).toBe('completed')
+    expect(outcome.detail).toContain('server fake-stdio 9.9.9')
+  })
+
+  it('reports failure when the child exits without responding', async () => {
+    const outcome = await probeStdio(
+      { kind: 'stdio', command: process.execPath, args: ['-e', 'process.exit(0)'], env: {} },
+      5000,
+      NEVER_ABORTED,
+    )
+    expect(outcome.status).toBe('failed')
+    expect(outcome.detail).toContain('process exited before initialize response')
   })
 })


### PR DESCRIPTION
## What

Extends connectivity probing to **stdio** MCP servers. Previously `mcp_probe`, the panel probe action, `/mcp <server> probe`, and the optional passive probe only supported streamable-http endpoints and rejected stdio rows outright (`stdio servers have no HTTP endpoint to probe`).

Now a probe on a stdio row:

- spawns the configured `command` / `args` with the scrubbed parent env + configured `env` (same `scrubbedParentEnv` policy as the mcp-client bridge) and optional `cwd`,
- completes one MCP `initialize` handshake over stdin/stdout,
- records the sanitized server name/version or a sanitized failure detail in the panel — still panel-only, with the same job semantics (unowned background job, cancel, per-probe timeout, display cap).

## Changes

- `src/probe.ts` — new `ProbeTarget` union (`http` | `stdio`), `probeStdio()`, `probeJob()` dispatch on transport; `mcp_probe` tool copy updated for both transports.
- `src/service.ts` — new `probeSpec()` that resolves either the raw HTTP endpoint or the stdio launch spec per mcp-client row; `probe()`, the passive sweep, and tool targeting all share it.
- `tests/probe.spec.ts` — stdio handshake + child-exit cases (real spawned node child, no network).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Notes

- The published bundle (`lib/`) is generated by `tsdown` and is not tracked in this repository, so no build artifacts are included.
- The stdio handshake path was manually validated against real stdio MCP servers before submission (initialize over stdio returns `serverInfo`).
- Follows the existing read-only / panel-only contract: probe credentials and details never reach logs, snapshots beyond the panel, or model context.
