### PR TITLE
feat: probe stdio MCP servers with an initialize handshake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,13 @@ Standalone DeepSeek Harness plugin repository (`dsh-mcp-panel`). Development fol
 ## Layout
 
 - `src/index.ts` — function-plugin contract (`name`/`inject`/`Config`/`apply`; NO default export — the Loader unwraps `exports.default ?? exports`).
-- `src/service.ts` — `McpPanelService` (`TypertRemoteService`, namespace `mcpPanel`): read-only snapshot assembly from loader rows + tool registry + upstream status observations. Serves `mcpPanel/status` and starts panel-only probes through `mcpPanel/probe` (`probe(serverName)`; needs `ctx.jobs`, streamable-http rows only).
+- `src/service.ts` — `McpPanelService` (`TypertRemoteService`, namespace `mcpPanel`): read-only snapshot assembly from loader rows + tool registry + upstream status observations. Serves `mcpPanel/status` and starts panel-only probes through `mcpPanel/probe` (`probe(serverName)`; needs `ctx.jobs`, streamable-http and stdio rows).
 - `src/wire.ts` — the snapshot vocabulary, its zod v4 wire schema, and the single `mcpPanel/status` invocation descriptor shared verbatim by the host `./typert` manifest (`src/typert.host.ts`) and the client Remote contribution (`src/client/remote.ts`) — one canonical source so the two codecs can never drift.
 - `src/upstream.ts` — the proposed upstream `mcp/status` seam (event + query service face), declared here via cordis declaration merging and consumed with feature detection; when upstream ships it, its identical declarations merge cleanly and a conflicting signature fails this compile (intended tripwire). Proposal text: `docs/upstream-proposal.md` in the deepseek-harness repo.
 - `src/sanitize.ts` — display redaction (URL query credentials, userinfo passwords, header values, bearer tokens, JWTs). Pure; extreme-case tests in `tests/sanitize.spec.ts`.
 - `src/grouping.ts` / `src/aggregate.ts` — pure enumeration/grouping and status aggregation with missing-field tolerance.
 - `src/command.ts` — the `/mcp` command (standard `CommandResult`; logged via `command/run` + `command/done`).
-- `src/probe.ts` — optional `mcp_probe` background-job tool (unowned job: panel-only results).
+- `src/probe.ts` — optional `mcp_probe` background-job tool (unowned job: panel-only results). Both transports probe: streamable-http via one `initialize` POST; stdio via spawning the row's `command`/`args` under `scrubbedParentEnv` (the same base the mcp-client bridge uses, imported from `@deepseek-ai/dsh-subprocess`) + explicit `env`/`cwd`, one `initialize` handshake over stdin/stdout, sanitized serverInfo or failure detail.
 - `src/client/` — browser half: `$mount` the Remote contribution, register the `settings.plugins.tab` entry id `mcp`, pure presenter in `present.ts`, inline scoped stylesheet in `styles.ts` (standalone bundles cannot use the in-repo CSS-module pipeline).
 - `tests/` — vitest; REAL `Context` + `Session`/`ToolRuntime`/`CommandRuntime` from the `0.1.0-rc.8` peers, fake Loader face, fake Agent, optional fake jobs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `mcp_probe`, the panel probe action, `/mcp <server> probe`, and the passive probe now support **stdio** MCP servers: a probe on a stdio row spawns the configured `command`/`args` under the same `scrubbedParentEnv` base the mcp-client bridge uses (credential-shaped and `DSH_*` names never leak into the child implicitly) plus the row's explicit `env`/`cwd`, completes one MCP `initialize` handshake over stdin/stdout, and records the sanitized server name/version or a sanitized failure detail — still panel-only, with the same unowned-job semantics (cancel, per-probe timeout, display cap). `ProbeTarget` is now a `kind`-discriminated union (`http` | `stdio`) resolved by `McpPanelService.probeSpec`; streamable-http rows are probed exactly as before.
+
 ## [0.4.2] - 2026-08-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
   "dependencies": {
     "tsdown": "^0.22.14",
     "typescript": "^7.0.0",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "@deepseek-ai/dsh-subprocess": ">=0.1.0-rc.8 <0.2.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@deepseek-ai/dsh-subprocess':
+        specifier: '>=0.1.0-rc.8 <0.2.0'
+        version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@7.0.2)
@@ -687,6 +690,12 @@ packages:
         optional: true
       '@deepseek-ai/dsh-user-approval':
         optional: true
+
+  '@deepseek-ai/dsh-subprocess@0.1.0-rc.8':
+    resolution: {integrity: sha512-rTWwWCq/WrBTjaXhApu7gaho6UHwMZq0+l7nZ06YMUreNZoCHfg67pAXopMqTgr/iotphmXQdChrLgBabzL1gA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
 
   '@deepseek-ai/dsh-system-prompt@0.1.0-rc.8':
     resolution: {integrity: sha512-yk8Z85rzX2EwpKNWA5i+K3I3mqsIIUc9niwbDpXO8vlHvpC2qR3RNHjJIJN2EZYDqfSzTVtkbxHFsuMzDXIbew==}
@@ -2434,6 +2443,11 @@ snapshots:
       '@deepseek-ai/dsh-session-projection': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.8(fbdb1d988541b64ff002d18c4ded7293))
       '@deepseek-ai/dsh-session-projection-cache': 0.1.0-rc.8(80a7956f091cdf0c220b226dd100fe03)
       '@deepseek-ai/dsh-user-approval': 0.1.0-rc.8(380a43f4d6510c4a5dfadf54dc7f17a7)
+
+  '@deepseek-ai/dsh-subprocess@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-system-prompt@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
     dependencies:

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -1,15 +1,22 @@
 /**
  * The optional `mcp_probe` tool: a one-shot connectivity probe of one
- * configured Streamable HTTP endpoint, executed as an UNOWNED background job.
- * Probe results are panel-only — the tool returns just the job id and a
- * pointer to the settings tab, the job carries no owner (so no completion
- * notice is injected into the model), and the panel reads the sanitized
- * snapshot back through `mcpPanel/status`.
+ * configured MCP server (streamable-http or stdio transport), executed as an
+ * UNOWNED background job. Probe results are panel-only — the tool returns
+ * just the job id and a pointer to the settings tab, the job carries no
+ * owner (so no completion notice is injected into the model), and the panel
+ * reads the sanitized snapshot back through `mcpPanel/status`.
+ *
+ * The stdio probe spawns the configured `command`/`args` with the same
+ * `scrubbedParentEnv` base the mcp-client bridge uses (credential-shaped and
+ * `DSH_*` names never leak into the child implicitly) plus the row's explicit
+ * `env`/`cwd`, and completes one MCP `initialize` handshake over stdin/stdout.
  *
  * @module dsh-mcp-panel/probe
  */
 
+import { spawn } from 'node:child_process'
 import type { JobHooks, JobOutcome, JobRegistry } from '@deepseek-ai/dsh-jobs'
+import { scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
 import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import { sanitizeError, sanitizeText } from './sanitize.ts'
@@ -20,7 +27,7 @@ export const PROBE_KIND = 'mcp-probe'
 
 declare module '@deepseek-ai/dsh-jobs' {
   interface JobKindMap {
-    /** One-shot Streamable HTTP connectivity probe (panel-only results). */
+    /** One-shot connectivity probe (streamable-http or stdio; panel-only results). */
     'mcp-probe': 'mcp-probe'
   }
 }
@@ -40,6 +47,17 @@ export interface ProbeOutcome {
   /** Sanitized one-line detail (HTTP status, latency, server info, or error). */
   detail: string
 }
+
+/** One configured server's probe spec: an HTTP endpoint or a stdio launch. */
+export type ProbeTarget =
+  | { readonly kind: 'http'; readonly url: string; readonly headers: Readonly<Record<string, string>> }
+  | {
+      readonly kind: 'stdio'
+      readonly command: string
+      readonly args: readonly string[]
+      readonly env: Readonly<Record<string, string>>
+      readonly cwd?: string
+    }
 
 /** Display cap for server-reported name/version fields in probe details. */
 const DISPLAY_LIMIT = 80
@@ -112,19 +130,118 @@ export async function probeEndpoint(
 }
 
 /**
- * Create the background-job hooks for one probe: cancel aborts the fetch, the
- * outcome settles `done` with sanitized detail only.
+ * Complete one MCP `initialize` handshake over a spawned stdio server's
+ * stdin/stdout and describe the outcome in one sanitized line. The child runs
+ * under the same `scrubbedParentEnv` base the mcp-client bridge uses —
+ * credential-shaped and `DSH_*` parent names never reach it implicitly — plus
+ * the row's explicit `env` (merged after the scrub) and optional `cwd`. The
+ * child's stderr is consumed and never rendered; the configured `command`/
+ * `args` are launch facts, not display content, but any error is sanitized
+ * before it lands in the outcome detail.
  *
- * @param url - endpoint URL.
- * @param headers - configured headers (used, never rendered).
+ * @param target - resolved stdio launch spec.
+ * @param timeoutMs - probe deadline.
+ * @param signal - caller-owned abort (job kill or timeout).
+ * @returns the settled probe outcome.
+ */
+export function probeStdio(
+  target: Extract<ProbeTarget, { kind: 'stdio' }>,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<ProbeOutcome> {
+  const started = Date.now()
+  return new Promise<ProbeOutcome>((resolve) => {
+    let settled = false
+    let child: ReturnType<typeof spawn> | undefined
+    let buffer = ''
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const finish = (outcome: ProbeOutcome): void => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) clearTimeout(timer)
+      try { child?.kill() } catch { /* already gone */ }
+      resolve(outcome)
+    }
+    timer = setTimeout(() => {
+      if (!settled) finish({ status: 'failed', detail: `timeout after ${timeoutMs}ms or cancelled` })
+    }, timeoutMs)
+    try {
+      child = spawn(target.command, [...target.args], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...scrubbedParentEnv(), ...target.env },
+        ...(target.cwd !== undefined && target.cwd !== '' ? { cwd: target.cwd } : {}),
+        windowsHide: true,
+      })
+    } catch (error) {
+      finish({ status: 'failed', detail: sanitizeError(error) })
+      return
+    }
+    child.on('error', (error) => finish({ status: 'failed', detail: sanitizeError(error) }))
+    child.on('exit', (code, signalName) => {
+      if (!settled) {
+        finish({ status: 'failed', detail: `process exited before initialize response (code ${code ?? 'null'}${signalName ? `, signal ${signalName}` : ''})` })
+      }
+    })
+    child.stdout?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8')
+      let index: number
+      while ((index = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, index).trim()
+        buffer = buffer.slice(index + 1)
+        if (line === '') continue
+        let message: { id?: unknown; result?: { serverInfo?: { name?: unknown; version?: unknown } } } | undefined
+        try {
+          message = JSON.parse(line) as typeof message
+        } catch {
+          continue
+        }
+        if (message !== null && typeof message === 'object' && message.id === 1 && message.result !== undefined) {
+          const serverInfo = message.result.serverInfo ?? {}
+          const name = typeof serverInfo.name === 'string' && serverInfo.name !== ''
+            ? boundedDisplay(sanitizeText(serverInfo.name))
+            : 'unnamed'
+          const version = typeof serverInfo.version === 'string' && serverInfo.version !== ''
+            ? boundedDisplay(sanitizeText(serverInfo.version))
+            : 'unknown version'
+          finish({ status: 'completed', detail: `MCP initialize ok over stdio (server ${name} ${version}) in ${Date.now() - started}ms` })
+          return
+        }
+      }
+    })
+    child.stderr?.on('data', () => { /* consumed, never rendered */ })
+    signal.addEventListener('abort', () => {
+      if (!settled) finish({ status: 'failed', detail: `timeout after ${timeoutMs}ms or cancelled` })
+    }, { once: true })
+    try {
+      child.stdin?.write(`${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: INITIALIZE_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: PROBE_CLIENT_INFO,
+        },
+      })}\n`)
+    } catch { /* the exit/error paths settle the outcome */ }
+  })
+}
+
+/**
+ * Create the background-job hooks for one probe: cancel aborts the fetch (or
+ * the spawned child), the outcome settles `done` with sanitized detail only.
+ *
+ * @param target - resolved probe spec (http endpoint or stdio launch).
  * @param timeoutMs - probe deadline.
  * @returns the registry hooks.
  */
-export function probeJob(url: string, headers: Readonly<Record<string, string>>, timeoutMs: number): JobHooks {
+export function probeJob(target: ProbeTarget, timeoutMs: number): JobHooks {
   const controller = new AbortController()
   const timer = setTimeout(() => { controller.abort() }, timeoutMs)
   timer.unref?.()
-  const done: Promise<JobOutcome> = probeEndpoint(url, headers, timeoutMs, controller.signal)
+  const done: Promise<JobOutcome> = (target.kind === 'stdio'
+    ? probeStdio(target, timeoutMs, controller.signal)
+    : probeEndpoint(target.url, target.headers, timeoutMs, controller.signal))
     .then(outcome => ({ ...outcome }))
     .finally(() => { clearTimeout(timer) })
   return {
@@ -133,12 +250,9 @@ export function probeJob(url: string, headers: Readonly<Record<string, string>>,
   }
 }
 
-/** Resolve one configured server's raw endpoint for probing. */
-function probeTarget(
-  service: McpPanelService,
-  server: string,
-): { url: string; headers: Record<string, string> } | undefined {
-  return service.rawEndpoint(server)
+/** Resolve one configured server's probe spec (http endpoint or stdio launch). */
+function probeTarget(service: McpPanelService, server: string): ProbeTarget | undefined {
+  return service.probeSpec(server)
 }
 
 /**
@@ -152,13 +266,13 @@ function probeTarget(
 export function mcpProbeTool(service: McpPanelService, jobs: JobRegistry, timeoutMs: number): ToolDefinition {
   return defineTool({
     name: 'mcp_probe',
-    description: 'Run a one-shot connectivity probe of a configured streamable-http MCP server as a background job. '
+    description: 'Run a one-shot connectivity probe of a configured MCP server (streamable-http or stdio) as a background job. '
       + 'Results appear in the MCP settings panel only — they are not injected into model context.',
     parameters: {
       server: {
         type: 'string',
         required: true,
-        description: 'serverName of a configured streamable-http MCP server (see /mcp for the list).',
+        description: 'serverName of a configured MCP server (see /mcp for the list); streamable-http and stdio transports are both supported.',
       },
     },
     output: {
@@ -179,15 +293,14 @@ export function mcpProbeTool(service: McpPanelService, jobs: JobRegistry, timeou
       const target = probeTarget(service, args.server)
       if (target === undefined) {
         throw new Error(
-          `mcp_probe: "${args.server}" is not a configured streamable-http MCP server (see /mcp). `
-          + 'stdio servers have no HTTP endpoint to probe.',
+          `mcp_probe: "${args.server}" is not a configured MCP server (see /mcp).`,
         )
       }
       const jobId = jobs.start({
         kind: PROBE_KIND,
         label: `mcp_probe ${args.server}`,
         // Unowned: no model completion notice, readable by the panel only.
-        run: () => probeJob(target.url, target.headers, timeoutMs),
+        run: () => probeJob(target, timeoutMs),
       })
       return {
         jobId,

--- a/src/service.ts
+++ b/src/service.ts
@@ -51,7 +51,7 @@ import {
 } from './patch.ts'
 import { appendPatchFragment } from './write.ts'
 import { createTrialCaller, validateTrialRequest, type McpAgentRegistryFace, type McpTrialRequest } from './trial.ts'
-import { probeEndpoint, probeJob, PROBE_KIND } from './probe.ts'
+import { probeJob, PROBE_KIND, type ProbeTarget } from './probe.ts'
 import { sanitizeText } from './sanitize.ts'
 import type { McpServerStatus, McpStatusPhase } from './upstream.ts'
 import type {
@@ -312,18 +312,18 @@ private readonly trialCaller = createTrialCaller()
   }
 
   /**
-   * Start a one-shot connectivity probe of one configured streamable-http
-   * server as an UNOWNED background job — panel-only, like the `mcp_probe`
-   * tool, but callable from the settings tab. Exported on the wire by the
-   * `mcpPanel/probe` invocation descriptor.
+   * Start a one-shot connectivity probe of one configured MCP server
+   * (streamable-http or stdio) as an UNOWNED background job — panel-only,
+   * like the `mcp_probe` tool, but callable from the settings tab. Exported
+   * on the wire by the `mcpPanel/probe` invocation descriptor.
    *
    * @param serverName - configured namespace.
    * @returns the started job id and where the result lands.
    */
   probe(serverName: string): ProbeStarted {
-    const target = this.rawEndpoint(serverName)
+    const target = this.probeSpec(serverName)
     if (target === undefined) {
-      throw new Error(`dsh-mcp-panel: "${serverName}" is not a configured streamable-http MCP server`)
+      throw new Error(`dsh-mcp-panel: "${serverName}" is not a configured MCP server (streamable-http or stdio)`)
     }
     const jobs = this.ctx.get('jobs')
     if (jobs === undefined) {
@@ -333,7 +333,7 @@ private readonly trialCaller = createTrialCaller()
       kind: PROBE_KIND,
       label: `mcp_probe ${serverName}`,
       // Unowned: no model completion notice, readable by the panel only.
-      run: () => probeJob(target.url, target.headers, this.config.probeTimeoutMs),
+      run: () => probeJob(target, this.config.probeTimeoutMs),
     })
     return {
       jobId,
@@ -486,7 +486,7 @@ private readonly trialCaller = createTrialCaller()
     return new Error(`dsh-mcp-panel: invalid patch operation — ${resolution.issues.map(issue => issue.text).join(' ')}`)
   }
 
-  /** One passive-probe sweep over every configured streamable-http server. */
+  /** One passive-probe sweep over every configured MCP server (both transports). */
   private async runPassiveProbes(): Promise<void> {
     if (this.passiveRunning) return
     this.passiveRunning = true
@@ -494,9 +494,9 @@ private readonly trialCaller = createTrialCaller()
       for (const entry of this.ctx.loader.entries()) {
         if (entry.options.name !== MCP_CLIENT_MODULE) continue
         const serverName = serverNameOf(entry.options.config, `entry:${entry.options.id}`)
-        const target = this.rawEndpoint(serverName)
+        const target = this.probeSpec(serverName)
         if (target === undefined) continue
-        const outcome = await probeEndpoint(target.url, target.headers, this.config.probeTimeoutMs, AbortSignal.timeout(this.config.probeTimeoutMs))
+        const outcome = await probeJob(target, this.config.probeTimeoutMs).done
         this.probeStates.set(serverName, { state: outcome.status === 'completed' ? 'reachable' : 'unreachable', checkedAt: Date.now() })
       }
     } finally {
@@ -505,15 +505,18 @@ private readonly trialCaller = createTrialCaller()
   }
 
   /**
-   * Resolve one server's raw endpoint for the probe tool. Credentials stay
-   * inside this return value and are used for the request only — they never
-   * reach a snapshot, a log, or a display.
+   * Resolve one configured server's probe spec. Credentials stay inside the
+   * returned value and are used for the probe only — they never reach a
+   * snapshot, a log, or a display. Streamable-http rows yield their raw
+   * endpoint + configured headers; stdio rows yield the launch spec
+   * (`command`/`args`, explicit `env` merged after the scrub, optional
+   * `cwd`) that the probe spawns.
    *
    * @param serverName - configured namespace.
-   * @returns the raw URL + configured headers, or `undefined` when the server
-   *   is not a configured streamable-http row.
+   * @returns the transport-tagged probe spec, or `undefined` when the server
+   *   is not a configured MCP row of either transport.
    */
-  rawEndpoint(serverName: string): { url: string; headers: Record<string, string> } | undefined {
+  probeSpec(serverName: string): ProbeTarget | undefined {
     for (const entry of this.ctx.loader.entries()) {
       if (entry.options.name !== MCP_CLIENT_MODULE) continue
       const config = entry.options.config
@@ -524,19 +527,58 @@ private readonly trialCaller = createTrialCaller()
       if (serverNameOf(config, `entry:${entry.options.id}`) !== serverName) continue
       if (typeof config !== 'object' || config === null || Array.isArray(config)) return undefined
       const row = config as Record<string, unknown>
-      if (row['transport'] !== 'streamable-http') return undefined
-      const url = row['url']
-      if (typeof url !== 'string' || url === '') return undefined
-      const headersValue = row['headers']
-      const headers: Record<string, string> = {}
-      if (typeof headersValue === 'object' && headersValue !== null && !Array.isArray(headersValue)) {
-        for (const [name, value] of Object.entries(headersValue as Record<string, unknown>)) {
-          if (typeof value === 'string') headers[name] = value
+      if (row['transport'] === 'streamable-http') {
+        const url = row['url']
+        if (typeof url !== 'string' || url === '') return undefined
+        const headersValue = row['headers']
+        const headers: Record<string, string> = {}
+        if (typeof headersValue === 'object' && headersValue !== null && !Array.isArray(headersValue)) {
+          for (const [name, value] of Object.entries(headersValue as Record<string, unknown>)) {
+            if (typeof value === 'string') headers[name] = value
+          }
         }
+        return { kind: 'http', url, headers }
       }
-      return { url, headers }
+      if (row['transport'] === 'stdio') {
+        const command = row['command']
+        if (typeof command !== 'string' || command === '') return undefined
+        const argsValue = row['args']
+        const args: string[] = []
+        if (Array.isArray(argsValue)) {
+          for (const value of argsValue) {
+            if (typeof value !== 'string') return undefined
+            args.push(value)
+          }
+        } else if (argsValue !== undefined) return undefined
+        const envValue = row['env']
+        const env: Record<string, string> = {}
+        if (typeof envValue === 'object' && envValue !== null && !Array.isArray(envValue)) {
+          for (const [name, value] of Object.entries(envValue as Record<string, unknown>)) {
+            if (typeof value !== 'string') return undefined
+            env[name] = value
+          }
+        } else if (envValue !== undefined) return undefined
+        const cwd = row['cwd']
+        if (cwd !== undefined && (typeof cwd !== 'string' || cwd === '')) return undefined
+        return { kind: 'stdio', command, args, env, ...(typeof cwd === 'string' ? { cwd } : {}) }
+      }
+      return undefined
     }
     return undefined
+  }
+
+  /**
+   * Resolve one server's raw endpoint for the streamable-http probe path.
+   * Credentials stay inside this return value and are used for the request
+   * only — they never reach a snapshot, a log, or a display.
+   *
+   * @param serverName - configured namespace.
+   * @returns the raw URL + configured headers, or `undefined` when the server
+   *   is not a configured streamable-http row.
+   */
+  rawEndpoint(serverName: string): { url: string; headers: Record<string, string> } | undefined {
+    const spec = this.probeSpec(serverName)
+    return spec?.kind === 'http' ? { url: spec.url, headers: { ...spec.headers } } : undefined
   }
 
   /** Unowned `mcp-probe` background jobs, newest first, sanitized for display. */

--- a/tests/command.spec.ts
+++ b/tests/command.spec.ts
@@ -242,13 +242,13 @@ describe('mcp_probe tool (optional)', () => {
     expect(jobs.started[0]!.owner).toBeUndefined()
   })
 
-  it('rejects unknown and stdio servers', async () => {
+  it('probes stdio servers and rejects unknown names', async () => {
     const harness = await mountHarness([mcpRow('mcp-github', GITHUB_CONFIG)], {}, fakeJobs() as never)
     const definition = harness.ctx.tools.get('mcp_probe')!
-    await expect(definition.execute({ server: 'github' }, { signal: new AbortController().signal } as never))
-      .rejects.toThrow('not a configured streamable-http MCP server')
+    const result = await definition.execute({ server: 'github' }, { signal: new AbortController().signal } as never) as { jobId: string }
+    expect(result.jobId).toBe('mcp-probe-1')
     await expect(definition.execute({ server: 'missing' }, { signal: new AbortController().signal } as never))
-      .rejects.toThrow('not a configured streamable-http MCP server')
+      .rejects.toThrow('not a configured MCP server (see /mcp)')
   })
 
   it('can be disabled by config', async () => {
@@ -268,11 +268,11 @@ describe('/mcp <server> probe command action', () => {
     expect(jobs.started).toEqual([{ kind: 'mcp-probe', label: 'mcp_probe web', owner: undefined }])
   })
 
-  it('reports stdio servers as an error result', async () => {
+  it('starts a stdio probe for stdio servers', async () => {
     const harness = await mountHarness([mcpRow('mcp-github', GITHUB_CONFIG)], {}, fakeJobs() as never)
     const result = await runCommand(harness, '/mcp github probe')
-    expect(result?.result.kind).toBe('error')
-    expect(text(result)).toContain('not a configured streamable-http MCP server')
+    expect(result?.result.kind).toBe('success')
+    expect(text(result)).toContain('Probe started for "github" (background job mcp-probe-1)')
   })
 
   it('reports a missing job registry as an error result', async () => {

--- a/tests/lifecycle.spec.ts
+++ b/tests/lifecycle.spec.ts
@@ -116,7 +116,7 @@ describe('mcp_probe three interfaces', () => {
         properties: {
           server: {
             type: 'string',
-            description: 'serverName of a configured streamable-http MCP server (see /mcp for the list).',
+            description: 'serverName of a configured MCP server (see /mcp for the list); streamable-http and stdio transports are both supported.',
           },
         },
         required: ['server'],

--- a/tests/probe-server.spec.ts
+++ b/tests/probe-server.spec.ts
@@ -80,7 +80,7 @@ describe('probeEndpoint against a sealed fake server', () => {
 
 describe('probeJob timeout against a sealed fake server', () => {
   it('aborts a hanging endpoint and settles the done hook as failed', async () => {
-    const hooks = probeJob(`${baseUrl}/hang`, {}, 50)
+    const hooks = probeJob({ kind: 'http', url: `${baseUrl}/hang`, headers: {} }, 50)
     const outcome = await hooks.done
     expect(outcome).toMatchObject({ status: 'failed' })
     expect(outcome.detail).toMatch(/timeout after 50ms or cancelled/)

--- a/tests/probe.spec.ts
+++ b/tests/probe.spec.ts
@@ -1,14 +1,16 @@
 /**
- * Probe network-path tests: the `fetch` legs of `probeEndpoint` and the
- * `probeJob` cancel contract. The fetch global is stubbed per case — no real
- * network. Covers 2xx/JSON, 2xx/non-JSON, non-2xx, network failure
- * sanitization, abort, display truncation, and the never-rejecting done hook.
+ * Probe path tests: the `fetch` legs of `probeEndpoint`, the `probeJob`
+ * cancel contract, and the `probeStdio` handshake over real spawned children.
+ * The fetch global is stubbed per case — no real network. Covers 2xx/JSON,
+ * 2xx/non-JSON, non-2xx, network failure sanitization, abort, display
+ * truncation, the never-rejecting done hook, the stdio initialize handshake,
+ * and the child-exit/spawn-failure paths.
  *
  * @module dsh-mcp-panel/test/probe.spec
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { probeEndpoint, probeJob } from '../src/probe.ts'
+import { probeEndpoint, probeJob, probeStdio } from '../src/probe.ts'
 
 /** Minimal fetch Response face the probe reads. */
 function fakeResponse(status: number, statusText: string, jsonBody?: unknown): Response {
@@ -106,7 +108,7 @@ describe('probeJob', () => {
         signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
       })
     }))
-    const hooks = probeJob('https://example.com/mcp', {}, 1000)
+    const hooks = probeJob({ kind: 'http', url: 'https://example.com/mcp', headers: {} }, 1000)
     hooks.cancel()
     const outcome = await hooks.done
     expect(outcome.status).toBe('failed')
@@ -116,8 +118,41 @@ describe('probeJob', () => {
     vi.stubGlobal('fetch', vi.fn(async () => fakeResponse(200, 'OK', {
       result: { serverInfo: { name: 'srv', version: '0.1.0' } },
     })))
-    const hooks = probeJob('https://example.com/mcp', {}, 1000)
+    const hooks = probeJob({ kind: 'http', url: 'https://example.com/mcp', headers: {} }, 1000)
     const outcome = await hooks.done
     expect(outcome.status).toBe('completed')
+  })
+})
+
+describe('probeStdio', () => {
+  it('completes an initialize handshake over a real stdio child', async () => {
+    const script = 'const line = await new Promise((r) => process.stdin.once("data", (d) => r(d.toString())))'
+      + '; process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { serverInfo: { name: "fake-stdio", version: "9.9.9" } } }) + "\\n")'
+    const outcome = await probeStdio(
+      { kind: 'stdio', command: process.execPath, args: ['-e', script], env: {} },
+      5000,
+      NEVER_ABORTED,
+    )
+    expect(outcome.status).toBe('completed')
+    expect(outcome.detail).toContain('server fake-stdio 9.9.9')
+  })
+
+  it('reports failure when the child exits without responding', async () => {
+    const outcome = await probeStdio(
+      { kind: 'stdio', command: process.execPath, args: ['-e', 'process.exit(0)'], env: {} },
+      5000,
+      NEVER_ABORTED,
+    )
+    expect(outcome.status).toBe('failed')
+    expect(outcome.detail).toContain('process exited before initialize response')
+  })
+
+  it('reports a sanitized failure when the spawn itself fails', async () => {
+    const outcome = await probeStdio(
+      { kind: 'stdio', command: 'definitely-not-a-command-7f3e', args: [], env: {} },
+      5000,
+      NEVER_ABORTED,
+    )
+    expect(outcome.status).toBe('failed')
   })
 })

--- a/tests/service.spec.ts
+++ b/tests/service.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Host service tests: the panel probe action (streamable-http gating, jobs
- * gating, unowned job start), the probe-record cap, and passive-probe state
+ * Host service tests: the panel probe action (transport gating, jobs gating,
+ * unowned job start), the probe-record cap, and passive-probe state
  * aggregation. No network — the fetch path is covered in `probe.spec.ts`.
  *
  * @module dsh-mcp-panel/test/service.spec
@@ -50,10 +50,18 @@ describe('McpPanelService.probe', () => {
     expect(jobs.started).toEqual([{ kind: 'mcp-probe', label: 'mcp_probe web', owner: undefined }])
   })
 
-  it('rejects stdio servers and unknown names', async () => {
+  it('starts an unowned panel-only probe job for a stdio server', async () => {
+    const jobs = fakeJobs()
+    const harness = await mountHarness([mcpRow('mcp-cli', STDIO_CONFIG)], {}, jobs as never)
+    const result = harness.service.probe('cli')
+    expect(result.jobId).toBe('mcp-probe-1')
+    expect(result.note).toContain('panel-only')
+    expect(jobs.started).toEqual([{ kind: 'mcp-probe', label: 'mcp_probe cli', owner: undefined }])
+  })
+
+  it('rejects unknown names', async () => {
     const harness = await mountHarness([mcpRow('mcp-cli', STDIO_CONFIG)], {}, fakeJobs() as never)
-    expect(() => harness.service.probe('cli')).toThrow('not a configured streamable-http MCP server')
-    expect(() => harness.service.probe('missing')).toThrow('not a configured streamable-http MCP server')
+    expect(() => harness.service.probe('missing')).toThrow('not a configured MCP server (streamable-http or stdio)')
   })
 
   it('fails loudly when no job registry is composed', async () => {


### PR DESCRIPTION
## What

Extends connectivity probing to **stdio** MCP servers — rebased and adapted from @feiler0's [PR #7](https://github.com/PerryLink/dsh-mcp-panel/pull/7) (closed without a review note; this lands the feature with authorship credited).

Previously `mcp_probe`, the panel probe action, `/mcp <server> probe`, and the optional passive probe only supported streamable-http endpoints and rejected stdio rows outright. Now a probe on a stdio row:

- spawns the configured `command` / `args` under the same `scrubbedParentEnv` base the mcp-client bridge uses (credential-shaped and `DSH_*` names never leak into the child implicitly) plus the row's explicit `env` and optional `cwd`,
- completes one MCP `initialize` handshake over stdin/stdout,
- records the sanitized server name/version or a sanitized failure detail in the panel — still panel-only, with the same unowned-job semantics (cancel, per-probe timeout, display cap).

## Changes vs #7

- `ProbeTarget` is a `kind`-discriminated union (`http` | `stdio`) resolved by the new `McpPanelService.probeSpec`; the tool, the panel action, and the passive sweep all share it.
- Adapted onto current `main` (probe/job signatures moved since #7 was filed) and fixed the #7 branch's own probeJob test-signature misses.
- Added `@deepseek-ai/dsh-subprocess` (`>=0.1.0-rc.8 <0.2.0`) as a runtime dependency for `scrubbedParentEnv`.
- Regression tests: stdio handshake over a real spawned child, child-exit and spawn-failure paths, stdio gating in the service and command specs.

## Checks

`pnpm run typecheck && pnpm run typecheck:ci && pnpm run lint && pnpm test && pnpm run build && pnpm run verify:self-contained && pnpm run verify:artifacts && pnpm pack` — all green locally (159/159 tests).
