### PR TITLE
docs: add official-repository declaration to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 *Official client = bridge, this plugin = console: read status through the `mcp/status` seam, write only append-only, approval-gated profile patches.*
 
+> **Official repository.** This is the only official repository of dsh-mcp-panel, maintained by PerryLink. Same-name repositories under other accounts are not affiliated.
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![DSH plugin](https://img.shields.io/badge/dsh-plugin-✅-green)](https://github.com/topics/dsh-plugin)
 [![Node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-brightgreen.svg)](#)

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,8 @@
 
 *官方 client = 桥接，本插件 = 控制台：经 `mcp/status` seam 读取状态，只写入只追加、走审批的 profile patch。*
 
+> **官方仓库。** 本仓库是 dsh-mcp-panel 的唯一官方仓库，由 PerryLink 维护。其他账号下的同名仓库与本项目无关。
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![DSH plugin](https://img.shields.io/badge/dsh-plugin-✅-green)](https://github.com/topics/dsh-plugin)
 [![Node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-brightgreen.svg)](#)


### PR DESCRIPTION
Adds the official-repository declaration (en/zh) for brand protection against same-name repositories. Same-name repos under other accounts are not affiliated.